### PR TITLE
refactor: Clean and refactor autopilot tests

### DIFF
--- a/housefly-autopilot/test/test.c
+++ b/housefly-autopilot/test/test.c
@@ -35,14 +35,16 @@ void should_reset_flight_state() {
 }
 
 /**
- * @brief Regardless of the flags, the new state can not be set to GND if the
- * the current state is invalid either
+ * @brief Regardless of the flags, the new state can not be set to GND if
+ * the current state exists in the invalid array
  */
-void should_validation_return_false_for_GND() {
+void should_validation_return_false_for_new_state_GND() {
   FlightState new_state = GND_STAT;
   FlightState possible_invalid_current_states[] = {TO_STAT, IDLE_STAT, GND_STAT,
                                                    TRN_STAT, HLT_STAT};
-  for (int i = 0; i < 5; i += 1) {
+  int len = sizeof(possible_invalid_current_states) / sizeof(int);
+
+  for (int i = 0; i < len; i += 1) {
     for (int j = 0; j < 256; j += 1) {
       int result = validate_requested_state(possible_invalid_current_states[i],
                                             new_state, j);
@@ -51,28 +53,47 @@ void should_validation_return_false_for_GND() {
   }
 }
 
-/**
- *@brief with valid flags the validation should return 1
- */
-void should_validation_return_true_for_GND() {
+void should_validation_return_true_for_new_state_GND() {
   FlightState new_state = GND_STAT;
-  FlightState possible_invalid_current_states[] = {NON_STAT, TST_STAT,
-                                                   LND_STAT};
-  for (int i = 0; i < 3; i += 1) {
-    int result = validate_requested_state(possible_invalid_current_states[i],
-                                          new_state, 0x01);
-    TEST_ASSERT_EQUAL(result, 1);
+  FlightState possible_valid_current_states[] = {NON_STAT, TST_STAT, LND_STAT};
+  int len = sizeof(possible_valid_current_states) / sizeof(int);
+
+  for (int i = 0; i < len; i += 1) {
+    for (int j = 0; j < 256; j += 1) {
+      int result = validate_requested_state(possible_valid_current_states[i],
+                                            new_state, j);
+      TEST_ASSERT_EQUAL(result, 1);
+    }
   }
 }
 
-/*  SUITES */
-void suite_state_management() {
-  should_reset_safety_test_flag();
-  should_set_safety_test_flag();
-  should_reset_all_flags();
-  should_reset_flight_state();
-  should_validation_return_false_for_GND();
-  should_validation_return_true_for_GND();
+void should_validation_return_false_for_new_state_TO() {
+  FlightState new_state = TO_STAT;
+  FlightState possible_invalid_current_states[] = {
+      TO_STAT, TRN_STAT, LND_STAT, NON_STAT, IDLE_STAT, TST_STAT, HLT_STAT};
+  int len = sizeof(possible_invalid_current_states) / sizeof(int);
+
+  for (int i = 0; i < len; i += 1) {
+    for (int j = 0; j < 256; j += 1) {
+      int result = validate_requested_state(possible_invalid_current_states[i],
+                                            new_state, j);
+      TEST_ASSERT_EQUAL(result, 0);
+    }
+  }
+}
+
+void should_validation_return_true_for_new_state_TO() {
+  FlightState new_state = TO_STAT;
+  FlightState possible_valid_current_states[] = {GND_STAT};
+  /* Flight safety flag is set to 1 */
+  int flags = 0x01;
+  int len = sizeof(possible_valid_current_states) / sizeof(int);
+
+  for (int i = 0; i < len; i += 1) {
+    int result = validate_requested_state(possible_valid_current_states[i],
+                                          new_state, flags);
+    TEST_ASSERT_EQUAL(result, 1);
+  }
 }
 
 void setUp(void) {}
@@ -80,6 +101,13 @@ void tearDown(void) {}
 
 int main() {
   UNITY_BEGIN();
-  RUN_TEST(suite_state_management);
+  RUN_TEST(should_reset_safety_test_flag);
+  RUN_TEST(should_set_safety_test_flag);
+  RUN_TEST(should_reset_all_flags);
+  RUN_TEST(should_reset_flight_state);
+  RUN_TEST(should_validation_return_false_for_new_state_GND);
+  RUN_TEST(should_validation_return_true_for_new_state_GND);
+  RUN_TEST(should_validation_return_false_for_new_state_TO);
+  RUN_TEST(should_validation_return_true_for_new_state_TO);
   return UNITY_END();
 }


### PR DESCRIPTION
### Changes

1. Adds test functions individually using `Unity RUN_TEST` for more clarity
2. Adds two new tests for the `Take off` state
3. Fixes a small bug in one of the test functions 